### PR TITLE
Ensure to get a mutableCopy of NSArray

### DIFF
--- a/SHGameCenter/GKTurnBasedMatch+SHGameCenter.m
+++ b/SHGameCenter/GKTurnBasedMatch+SHGameCenter.m
@@ -402,7 +402,7 @@ matchEventInvitesBlock:(SHGameMatchEventInvitesBlock)theMatchEventInvitesBlock; 
     return result;
     
     
-  }].copy;
+  }].mutableCopy;
   
   GKTurnBasedParticipant * firstParticipant = participants.SH_firstObject;
   


### PR DESCRIPTION
Use mutableCopy to ensure participants is NSMutableArray. Otherwise it will reports error in iOS 7 and later.
